### PR TITLE
fix CFLAGS & LDFLAGS overwrite for aarch64

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -64,6 +64,7 @@ matrix:
     - MB_PYTHON_VERSION=3.5
     - PLAT=aarch64
     - MB_ML_VER=2014
+    - DOCKER_TEST_IMAGE=multibuild/xenial_arm64v8
   - os: linux
     env:
     - MB_PYTHON_VERSION=3.6
@@ -77,6 +78,7 @@ matrix:
     - MB_PYTHON_VERSION=3.6
     - PLAT=aarch64
     - MB_ML_VER=2014
+    - DOCKER_TEST_IMAGE=multibuild/xenial_arm64v8
   - os: linux
     env:
     - MB_PYTHON_VERSION=3.7
@@ -90,6 +92,7 @@ matrix:
     - MB_PYTHON_VERSION=3.7
     - PLAT=aarch64
     - MB_ML_VER=2014
+    - DOCKER_TEST_IMAGE=multibuild/xenial_arm64v8
   - os: linux
     env:
     - MB_PYTHON_VERSION=3.8
@@ -103,6 +106,7 @@ matrix:
     - MB_PYTHON_VERSION=3.8
     - PLAT=aarch64
     - MB_ML_VER=2014
+    - DOCKER_TEST_IMAGE=multibuild/xenial_arm64v8
 
 before_install:
 - source multibuild/common_utils.sh

--- a/config.sh
+++ b/config.sh
@@ -14,12 +14,6 @@
 function bdist_with_static_deps {
     local abs_wheelhouse=$1
     python setup.py clean
-    if [ -n "$IS_OSX" ]; then
-        export CFLAGS="$CFLAGS -flto";
-	export LDFLAGS="$LDFLAGS -arch x86_64";
-    else
-        export CFLAGS="-O3 -mtune=core2 -pipe -fPIC -flto";
-    fi
     make wheel_static
     cp dist/*.whl $abs_wheelhouse
 }

--- a/propagate_env_vars.py
+++ b/propagate_env_vars.py
@@ -60,10 +60,7 @@ def main():
             if "=" in env_var
         ])
     elif IS_OSX:
-        env.update({
-            "CFLAGS": "$CFLAGS -flto",
-            "LDFLAGS": "$LDFLAGS -arch x86_64",
-        })
+        append_env(env, "LDFLAGS", "-arch x86_64")
 
     env_vars = [
         (name, env[name])

--- a/propagate_env_vars.py
+++ b/propagate_env_vars.py
@@ -4,6 +4,7 @@ import re
 
 
 IS_ARM64 = platform.processor() == "aarch64"
+IS_OSX = platform.system() == "Darwin"
 
 ENV_VARS = [
     "STATIC_DEPS",
@@ -58,6 +59,11 @@ def main():
             for env_var in (" " + read_makefile_var("AARCH64_ENV") + " ").split(" -e ")
             if "=" in env_var
         ])
+    elif IS_OSX:
+        env.update({
+            "CFLAGS": "$CFLAGS -flto",
+            "LDFLAGS": "$LDFLAGS -arch x86_64",
+        })
 
     env_vars = [
         (name, env[name])


### PR DESCRIPTION
this fixes [failing aarch64 builds](https://github.com/lxml/lxml/pull/304#issuecomment-660631358).
The problem was  that `config.sh` is sourced by multibuild after `env_vars.sh` causing an overwrite of environment variables